### PR TITLE
Fix environment variable for code execution

### DIFF
--- a/code_excecution/code_execute.py
+++ b/code_excecution/code_execute.py
@@ -7,8 +7,10 @@ from dotenv import load_dotenv
 # Load the .env file
 load_dotenv()
 
-# Read the value
-rapid_api_token = os.getenv('rapid_api_token')
+# Read the value from environment
+# The README specifies `RAPID_API_TOKEN` so we
+# read this variable to avoid case mismatch issues
+rapid_api_token = os.getenv('RAPID_API_TOKEN')
 
 
 


### PR DESCRIPTION
## Summary
- fix environment variable name for the code execution API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684078678dd08322b13f8350df3a4563